### PR TITLE
chore: remove unused langchain_google_genai dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 opencv-python
 langchain
 langchain-openai
-langchain_google_genai
 langchain-community
 python-dotenv
 pyaudio


### PR DESCRIPTION
## Summary
- remove langchain_google_genai from requirements
- verify repository has no references to langchain_google_genai

## Testing
- `pytest`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a74262ae548331b93e28369141d57e