### PR TITLE
Add error handling in audio callback

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,6 +153,8 @@ def audio_callback(recognizer, audio):
         assistant.answer(prompt, desktop_screenshot.read(encode=True))
     except UnknownValueError:
         print("There was an error processing the audio.")
+    except Exception as e:
+        print(f"Unexpected error: {e}")
 
 
 recognizer = Recognizer()


### PR DESCRIPTION
## Summary
- Wrap speech recognition and response generation in try/except to catch unexpected errors.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a74261d3d0833194beb4f7f18e7944