### PR TITLE
Safely stop screenshot thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ class DesktopScreenshot:
 
     def stop(self):
         self.running = False
-        if self.thread.is_alive():
+        if hasattr(self, "thread") and self.thread.is_alive():
             self.thread.join()
 
 


### PR DESCRIPTION
## Summary
- Guard DesktopScreenshot.stop against missing thread attribute
- Only join screenshot thread when it exists and is alive

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7425ebcb4833184da9c8c0e958156