### PR TITLE
Handle missing screenshot

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,9 +72,12 @@ class Assistant:
 
         print("Prompt:", prompt)
 
+        image_base64 = image.decode() if image is not None else ""
+
         response = self.chain.invoke(
             {
-                "prompt": prompt, "image_base64": image.decode()
+                "prompt": prompt,
+                "image_base64": image_base64,
             },
             config={
                 "configurable":


### PR DESCRIPTION
## Summary
- Guard assistant against missing screenshots by defaulting to empty image base64

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a711bbdef48331bd4336f3763be7f1