### PR TITLE
Handle missing screenshot before answering

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,11 @@ assistant = Assistant(model)
 def audio_callback(recognizer, audio):
     try:
         prompt = recognizer.recognize_whisper(audio, model="base", language="english")
-        assistant.answer(prompt, desktop_screenshot.read(encode=True))
+        image = desktop_screenshot.read(encode=True)
+        if image is None:
+            print("Skipping response: screenshot not available.")
+            return
+        assistant.answer(prompt, image)
     except UnknownValueError:
         print("There was an error processing the audio.")
 


### PR DESCRIPTION
## Summary
- Guard audio callback against missing screenshots to prevent runtime errors

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a71191b4088331836122a29d0d55e1