### PR TITLE
Add openai requirement and remove duplicate SpeechRecognition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ langchain
 langchain-openai
 langchain-community
 python-dotenv
+openai
 pyaudio
 soundfile
-SpeechRecognition
 SpeechRecognition[whisper-local]
 Pillow
 numpy


### PR DESCRIPTION
## Summary
- Add missing `openai` dependency after `python-dotenv`
- Remove duplicated `SpeechRecognition` entry to leave only `SpeechRecognition[whisper-local]`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement opencv-python due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a7499081f48331b8a04b14de072b4a