### PR TITLE
Add CLI options for model and voice

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -17,14 +17,16 @@ class Assistant:
     speech system to provide audible answers to user prompts.
     """
 
-    def __init__(self, model: ChatOpenAI) -> None:
-        """Initialize the assistant with the given language model.
+    def __init__(self, model: ChatOpenAI, voice: str) -> None:
+        """Initialize the assistant with the given language model and voice.
 
         Args:
             model: Chat model used to generate responses.
+            voice: Voice name used for text-to-speech.
         """
 
         self.chain = self._create_inference_chain(model)
+        self.voice = voice
 
     def answer(self, prompt: str, image: Optional[bytes]) -> None:
         """Generate a spoken answer for the provided prompt and image.
@@ -72,7 +74,7 @@ class Assistant:
 
         with openai.audio.speech.with_streaming_response.create(
             model="tts-1",
-            voice="shimmer",
+            voice=self.voice,
             response_format="pcm",
             input=response,
         ) as response_stream:

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import logging
+import argparse
 import cv2
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
@@ -10,13 +11,18 @@ from screenshots import DesktopScreenshot
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="gpt-4o")
+    parser.add_argument("--voice", default="shimmer")
+    args = parser.parse_args()
+
     load_dotenv()
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 
     desktop_screenshot = DesktopScreenshot().start()
-    model = ChatOpenAI(model="gpt-4o")
-    assistant = Assistant(model)
+    model = ChatOpenAI(model=args.model)
+    assistant = Assistant(model, voice=args.voice)
 
     def audio_callback(recognizer, audio):
         try:


### PR DESCRIPTION
## Summary
- add argparse options for selecting model and voice on the command line
- allow Assistant to accept a custom voice for TTS

## Testing
- `python -m py_compile main.py assistant.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install opencv-python-headless` *(fails: Could not find a version that satisfies the requirement opencv-python-headless)*

------
https://chatgpt.com/codex/tasks/task_e_68a752bd4458833181563301a2663ef3